### PR TITLE
Add optional skeletonization to batch segmentation pipeline

### DIFF
--- a/ex_segmentation/README.md
+++ b/ex_segmentation/README.md
@@ -70,6 +70,7 @@ verarbeitet wird.
 | `max_hole_size` | Maximale Größe zu füllender Löcher | `4` | [`PipelineParameters`](./batch_segment_multiple_images.py) |
 | `min_feature_size` | Kleinste zu erhaltende Komponenten | `64` | [`PipelineParameters`](./batch_segment_multiple_images.py) |
 | `invert_grayscale` | Eingangsbild invertieren, falls Grenzen dunkel sind | `False` | [`PipelineParameters`](./batch_segment_multiple_images.py) |
+| `skeletonize_output` / `apply_skeletonize` | Wendet eine abschließende Skelettierung auf die Binärmaske an | `False` | [`segment_image`](./batch_segment_multiple_images.py), [`build_manual_configuration`](./batch_segment_multiple_images.py) |
 
 Weitere Parameter (z. B. Plot-/Logging-Einstellungen) werden in den jeweiligen
 Skripten dokumentiert und künftig über Docstrings gepflegt.


### PR DESCRIPTION
## Summary
- add a manual configuration flag for enabling skeletonization in the batch segmentation pipeline
- propagate the new option through pipeline parameters and apply skeletonization when requested
- document the new option in the segmentation parameter reference

## Testing
- python -m compileall ex_segmentation

------
https://chatgpt.com/codex/tasks/task_e_68d149e15c38832fb6be9b0047758c45